### PR TITLE
Use the bind_timelimit when binding.

### DIFF
--- a/pam_ldap.c
+++ b/pam_ldap.c
@@ -2179,7 +2179,7 @@ retry:
     }
 #endif /* HAVE_LDAP_SASL_BIND && LDAP_SASL_SIMPLE */
 
-  timeout.tv_sec = 10;
+  timeout.tv_sec = session->conf->bind_timelimit;	/* default 10 */
   timeout.tv_usec = 0;
   rc = ldap_result (session->ld, msgid, FALSE, &timeout, &result);
   if (rc == -1 || rc == 0)


### PR DESCRIPTION
Anonymous binds set the proper bind_timelimit, but user binds use the
default value of 10s.

If the user bind takes longer than 10s, the bind can never succeed (OpenLDAP).