### PR TITLE
Fix broken referrals when doing password change EXOPs

### DIFF
--- a/pam_ldap.c
+++ b/pam_ldap.c
@@ -3248,6 +3248,19 @@ _update_authtok (pam_handle_t *pamh,
 
     case PASSWORD_EXOP:
     case PASSWORD_EXOP_SEND_OLD:
+      ////////////////////////////////////////////////////////////////////////////////////////////
+      //
+      // connect_as_user drops session->info->userpw.  This causes update referrals to break.
+      // We fix that here by installing old_password into session->info->userpw
+      //
+      ////////////////////////////////////////////////////////////////////////////////////////////
+      if (old_password && !session->info->userpw)
+        {
+	  session->info->userpw = strdup (old_password);
+	  if (session->info->userpw == NULL)
+	      return PAM_BUF_ERR;
+        }
+      ////////////////////////////////////////////////////////////////////////////////////////////
 #ifdef LDAP_EXOP_MODIFY_PASSWD
       ber = ber_alloc_t (LBER_USE_DER);
 


### PR DESCRIPTION
Environment is Ubuntu-16.04 using libpam-ldap (basically pam_ldap-184).  Our LDAP environment is one primary OpenLDAP server and some read-only secondary OpenLDAP servers using syncrepl.

I'm trying to configure password changes without using rootbinddn & /etc/ldap.secret.  I.e. user changes own password vi LDAP extended operation.

My problem is with forced password change operations where pam_ldap is talking to the secondary.  Referrals are not working, and I've traced it down, and can see how to fix it, but wanted to ask first and perhaps understand why it's not working for me.

This code in _connect_as_user (line 2198):

 if (session->info->policy_error != POLICY_ERROR_SUCCESS)
    {
      _pam_overwrite (session->info->userpw);
      _pam_drop (session->info->userpw);
    }
  /* else userpw is now set. Be sure to clobber it later. */

session->info->policy_error is == 2 (POLICY_ERROR_CHANGE_AFTER_RESET), causing session->info->userpw to be set to NULL.

Then in _update_auth_token (line 3149):

      rc =
         ldap_extended_operation_s (session->ld, LDAP_EXOP_MODIFY_PASSWD, bv,
             NULL, NULL, &retoid, &retdata);

This causes _rebind_proc to be called, and that point session->info->userpw is NULL & bind to the primary LDAP server fails.  I see this with LDAP debugging enabled:

Jan 27 11:11:45 ls3 lightdm[16258]: res_errno: 53, res_error: <unauthenticated bind (DN with no password) disallowed>, res_matched: <>

My solution is to add this code to _update_authtok (line 3121):

      if (old_password && !session->info->userpw)
        {
          session->info->userpw = strdup (old_password);
          if (session->info->userpw == NULL)
             return PAM_BUF_ERR;
        }